### PR TITLE
Improved translation to match space vocabulary

### DIFF
--- a/Resources/dictionary-fr-fr.cfg
+++ b/Resources/dictionary-fr-fr.cfg
@@ -17,7 +17,7 @@ Localization
 		#DCKROT_node_displayname = Nœud tournant
 		#DCKROT_node_info = La pièce connectée au nœud '<<1>>' peut tourner
 		#DCKROT_port_displayname = Port tournant
-		#DCKROT_port_info = Ce port peut tourner s'il est attaché à un autre port de même taille
+		#DCKROT_port_info = Ce port peut tourner s'il est arrimé à un autre port de même taille
 	}
 }
 


### PR DESCRIPTION
"attaché" is a generic word which means "fixed" as in the sentence "These two crates are fixed together".
"arrimé" is the exact word used for space docks.