### PR TITLE
Preliminary Restock Compatibility

### DIFF
--- a/Resources/DockRotate.restockwhitelist
+++ b/Resources/DockRotate.restockwhitelist
@@ -1,0 +1,3 @@
+//Whitelist Radial Attachment Point and Oscar B model so the parts load with restock install
+Squad/Parts/radialAttachmentPoint/
+Squad/Parts/FuelTank/fuelTankOscarB/model

--- a/Resources/DockRotate.restockwhitelist
+++ b/Resources/DockRotate.restockwhitelist
@@ -1,3 +1,3 @@
-//Whitelist Radial Attachment Point and Oscar B model so the parts load with restock install
+//Whitelist Radial Attachment Point and Oscar B model so the parts load with restock installed
 Squad/Parts/radialAttachmentPoint/
 Squad/Parts/FuelTank/fuelTankOscarB/model


### PR DESCRIPTION
The NodeRotate parts use stock models and/or textures, meaning they don't load when Restock is installed. This whitelist file will allow KSP to load the textures and models (and thus the parts), though changing them over to Restock assets is worth looking into. Note: It is currently untested but I can test it at about 10:30 PM UTC.